### PR TITLE
Consider organization in deployment

### DIFF
--- a/vars/PalladioPipeline.groovy
+++ b/vars/PalladioPipeline.groovy
@@ -34,8 +34,8 @@ def call(body) {
 }
 
 def constructDeployUpdatesiteProjectDir(scmUrl) {
-    def pattern = '/^.*[:/]([^:\/]+)\/([^\/]+?).git$/'
-    def matcher = scmUrl =~ pattern
+    def pattern = /^.*[:\/]([^\/]+)\/([^\/]+)\.git$/
+    def matcher = (scmUrl =~ pattern).findAll()
     if (matcher[0][1] == 'PalladioSimulator') {
         return matcher[0][2]
     }

--- a/vars/PalladioPipeline.groovy
+++ b/vars/PalladioPipeline.groovy
@@ -21,7 +21,7 @@ def call(body) {
         deployUpdatesiteSshName 'web'
         deployUpdatesiteRootDir '/home/sftp/data'
         deployUpdatesiteSubDir ("${this.BRANCH_NAME}" == 'master' ? 'nightly': "branches/${this.BRANCH_NAME}")
-        deployUpdatesiteProjectDir this.scm.userRemoteConfigs[0].url.replaceFirst(/^.*\/([^\/]+?).git$/, '$1').toLowerCase()
+        deployUpdatesiteProjectDir constructDeployUpdatesiteProjectDir(this.scm.userRemoteConfigs[0].url).toLowerCase()
 
         createCompositeUpdatesiteScriptFileId '608d94a5-3ba4-4601-9a07-46fab5b37752'
              
@@ -31,4 +31,13 @@ def call(body) {
         body.resolveStrategy = Closure.DELEGATE_FIRST
         body()
     }
+}
+
+def constructDeployUpdatesiteProjectDir(scmUrl) {
+    def pattern = '/^.*[:/]([^:\/]+)\/([^\/]+?).git$/'
+    def matcher = scmUrl =~ pattern
+    if (matcher[0][1] == 'PalladioSimulator') {
+        return matcher[0][2]
+    }
+    return matcher[0][1] + '/' + matcher[0][2]
 }


### PR DESCRIPTION
We have the option to integrate further organizations into our build server apart from Palladio. I think, it would be beneficial to deploy them to a separate directory on the update site to avoid mixing highly experiment features not maintained by Palladio with established projects. This PR creates a separate directory for each organization if it is not Palladio.

I would prefer a squash merge to cover up my fail in getting the groovy syntax right.